### PR TITLE
fix: resolve auth bypass in insights.ts

### DIFF
--- a/artifacts/api-server/src/routes/insights.ts
+++ b/artifacts/api-server/src/routes/insights.ts
@@ -15,22 +15,9 @@ import {
 } from "@workspace/db";
 import { and, eq, gte, sql, desc } from "drizzle-orm";
 import { resolveProfile } from "../lib/profile";
+import { requireGrownup } from "../lib/grownup-auth";
 
 const router: IRouter = Router();
-
-const IS_PROD = process.env.NODE_ENV === "production";
-const PASSCODE_SECRET = process.env.GROWNUPS_TOKEN_SECRET || "";
-const PASSCODE = process.env.GROWNUPS_PASSCODE || "1234";
-const TOKEN = `grownup:${PASSCODE_SECRET || PASSCODE}`;
-
-function gate(req: import("express").Request, res: import("express").Response): boolean {
-  const provided = req.header("x-grownup-token");
-  if (!provided || (IS_PROD ? provided !== TOKEN : !provided.startsWith("grownup:"))) {
-    res.status(401).json({ error: "Unauthorized" });
-    return false;
-  }
-  return true;
-}
 
 /**
  * Per-word vocabulary tracker. For each unique word the kid asked help with,
@@ -42,7 +29,7 @@ function gate(req: import("express").Request, res: import("express").Response): 
  * help request for the word since.
  */
 router.get("/grownups/vocabulary", async (req, res) => {
-  if (!gate(req, res)) return;
+  if (!requireGrownup(req, res)) return;
   const profile = await resolveProfile(req);
 
   const wordRows = await db
@@ -92,7 +79,7 @@ router.get("/grownups/vocabulary", async (req, res) => {
  * Streak-free, judgment-free.
  */
 router.get("/grownups/weekly-summary", async (req, res) => {
-  if (!gate(req, res)) return;
+  if (!requireGrownup(req, res)) return;
   const profile = await resolveProfile(req);
   const weekAgo = new Date();
   weekAgo.setDate(weekAgo.getDate() - 7);
@@ -152,7 +139,7 @@ router.get("/grownups/weekly-summary", async (req, res) => {
  * Privacy-friendly data export: returns everything stored for this profile.
  */
 router.get("/grownups/export", async (req, res) => {
-  if (!gate(req, res)) return;
+  if (!requireGrownup(req, res)) return;
   const profile = await resolveProfile(req);
 
   const [prefs, sessions, words, finished, owned, decor, txns, allChapters, allStories, allWorlds] = await Promise.all([


### PR DESCRIPTION
## Summary

Fixes #2 — Critical auth bypass in `insights.ts`.

### Problem
The `insights.ts` route was constructing its own grownup auth token independently:
```ts
const PASSCODE_SECRET = process.env.GROWNUPS_TOKEN_SECRET || "";
const PASSCODE = process.env.GROWNUPS_PASSCODE || "1234";
const TOKEN = `grownup:${PASSCODE_SECRET || PASSCODE}`;
```

This fell back to the hardcoded `grownup:1234` when `GROWNUPS_TOKEN_SECRET` was not set. Meanwhile, `grownups.ts` generates a random 32-byte secret for the token. This inconsistency meant the insights endpoints (`/grownups/vocabulary`, `/grownups/weekly-summary`, `/grownups/export`) could be accessed with `grownup:1234` even in environments where the real token used a random secret.

### Fix
- Removed the duplicate token construction and `gate()` function from `insights.ts`
- Imported `requireGrownup` from the shared `../lib/grownup-auth` module (already used by `profiles.ts` and `preferences.ts`)
- Replaced all `gate(req, res)` calls with `requireGrownup(req, res)`

This ensures all grownup-protected endpoints use the same authentication logic from a single source of truth.

### Changes
- `artifacts/api-server/src/routes/insights.ts` — 4 insertions, 17 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication logic for grownup-related endpoints to improve consistency and maintainability across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->