### PR TITLE
fix: security hardening — CORS, rate limiting, timing-safe comparison

### DIFF
--- a/artifacts/api-server/package.json
+++ b/artifacts/api-server/package.json
@@ -17,6 +17,7 @@
     "cors": "^2",
     "drizzle-orm": "catalog:",
     "express": "^5",
+    "express-rate-limit": "^7",
     "pino": "^9",
     "pino-http": "^10",
     "zod": "catalog:"

--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import pinoHttp from "pino-http";
 import path from "node:path";
 import fs from "node:fs";
@@ -27,7 +28,10 @@ app.use(
     },
   }),
 );
-app.use(cors());
+app.use(cors({
+  origin: process.env.ALLOWED_ORIGINS?.split(',').map(s => s.trim()) || ['http://localhost:3000'],
+  credentials: true,
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -1,6 +1,5 @@
 import express, { type Express } from "express";
 import cors from "cors";
-import rateLimit from "express-rate-limit";
 import pinoHttp from "pino-http";
 import path from "node:path";
 import fs from "node:fs";

--- a/artifacts/api-server/src/lib/grownup-auth.ts
+++ b/artifacts/api-server/src/lib/grownup-auth.ts
@@ -1,6 +1,17 @@
 import type { Request, Response } from "express";
+import { timingSafeEqual } from "node:crypto";
 
 const IS_PROD = process.env.NODE_ENV === "production";
+
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf-8");
+  const bufB = Buffer.from(b, "utf-8");
+  if (bufA.length !== bufB.length) {
+    // Still do a comparison to avoid leaking length info via timing
+    return timingSafeEqual(bufA, bufA);
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 /**
  * Grown-ups gate. In production we require an exact-token match against the
@@ -15,7 +26,7 @@ export function isGrownupAuthorized(req: Request): boolean {
   if (IS_PROD) {
     const secret = process.env.GROWNUPS_TOKEN_SECRET;
     if (!secret) return false;
-    return provided === `grownup:${secret}`;
+    return safeCompare(provided, `grownup:${secret}`);
   }
   return provided.startsWith("grownup:");
 }

--- a/artifacts/api-server/src/lib/grownup-auth.ts
+++ b/artifacts/api-server/src/lib/grownup-auth.ts
@@ -3,7 +3,7 @@ import { timingSafeEqual } from "node:crypto";
 
 const IS_PROD = process.env.NODE_ENV === "production";
 
-function safeCompare(a: string, b: string): boolean {
+export function safeCompare(a: string, b: string): boolean {
   const bufA = Buffer.from(a, "utf-8");
   const bufB = Buffer.from(b, "utf-8");
   if (bufA.length !== bufB.length) {

--- a/artifacts/api-server/src/routes/grownups.ts
+++ b/artifacts/api-server/src/routes/grownups.ts
@@ -11,18 +11,8 @@ import {
 import { and, desc, eq, gte, sql, inArray, countDistinct } from "drizzle-orm";
 import { GrownupsAuthBody } from "@workspace/api-zod";
 import { resolveProfile } from "../lib/profile";
+import { safeCompare } from "../lib/grownup-auth";
 import rateLimit from "express-rate-limit";
-import { timingSafeEqual } from "node:crypto";
-
-function safeCompare(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, "utf-8");
-  const bufB = Buffer.from(b, "utf-8");
-  if (bufA.length !== bufB.length) {
-    // Still do a comparison to avoid leaking length info via timing
-    return timingSafeEqual(bufA, bufA);
-  }
-  return timingSafeEqual(bufA, bufB);
-}
 
 const authLimiter = rateLimit({
   windowMs: 60 * 1000,

--- a/artifacts/api-server/src/routes/grownups.ts
+++ b/artifacts/api-server/src/routes/grownups.ts
@@ -11,6 +11,26 @@ import {
 import { and, desc, eq, gte, sql, inArray, countDistinct } from "drizzle-orm";
 import { GrownupsAuthBody } from "@workspace/api-zod";
 import { resolveProfile } from "../lib/profile";
+import rateLimit from "express-rate-limit";
+import { timingSafeEqual } from "node:crypto";
+
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf-8");
+  const bufB = Buffer.from(b, "utf-8");
+  if (bufA.length !== bufB.length) {
+    // Still do a comparison to avoid leaking length info via timing
+    return timingSafeEqual(bufA, bufA);
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  message: { error: "Too many attempts, please try again later" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 const router: IRouter = Router();
 
@@ -28,16 +48,16 @@ const TOKEN = `grownup:${TOKEN_SECRET}`;
 
 function requireGrownupAuth(req: { headers: Record<string, string | string[] | undefined> }): boolean {
   const provided = req.headers["x-grownup-token"];
-  return typeof provided === "string" && provided === TOKEN;
+  return typeof provided === "string" && safeCompare(provided, TOKEN);
 }
 
-router.post("/grownups/auth", (req, res) => {
+router.post("/grownups/auth", authLimiter, (req, res) => {
   const parsed = GrownupsAuthBody.safeParse(req.body);
   if (!parsed.success) {
     res.status(401).json({ error: "Wrong passcode" });
     return;
   }
-  if (parsed.data.passcode !== PASSCODE) {
+  if (!safeCompare(parsed.data.passcode, PASSCODE)) {
     res.status(401).json({ error: "Wrong passcode" });
     return;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       express:
         specifier: ^5
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^7
+        version: 7.5.1(express@5.2.1)
       pino:
         specifier: ^9
         version: 9.14.0
@@ -2941,6 +2944,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -6391,6 +6400,10 @@ snapshots:
       yoctocolors: 2.1.2
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
 
   express@5.2.1:
     dependencies:


### PR DESCRIPTION
## Security hardening — three fixes

This PR addresses three high-priority security issues:

### 1. CORS wildcard restriction (Closes #3)
- Replaced `cors()` (wildcard `*`) with explicit origin allowlist
- Origins configured via `ALLOWED_ORIGINS` env var (comma-separated)
- Falls back to `http://localhost:3000` when not configured
- `credentials: true` enabled for cookie-bearing requests

### 2. Rate limiting on auth endpoint (Closes #4)
- Added `express-rate-limit` dependency
- Auth endpoint (`POST /grownups/auth`) limited to **5 requests per minute**
- Returns `429` with a clear error message when exceeded
- Standard `RateLimit-*` headers enabled

### 3. Timing-safe comparison (Closes #5)
- Replaced all `===` comparisons for passcodes and tokens with `crypto.timingSafeEqual`
- Fixed in **3 locations**:
  - `grownups.ts`: passcode comparison + token validation
  - `grownup-auth.ts`: token validation (used by insights.ts and other routes)
- `safeCompare()` helper performs constant-time comparison, comparing against self when lengths differ to avoid length-leakage via timing

### Files changed
- `artifacts/api-server/src/app.ts` — CORS config
- `artifacts/api-server/src/routes/grownups.ts` — rate limiter + timing-safe comparison
- `artifacts/api-server/src/lib/grownup-auth.ts` — timing-safe comparison
- `artifacts/api-server/package.json` — added `express-rate-limit` dependency