### PR TITLE
fix: medium-priority improvements — error handling, docs, housekeeping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/reading_quest
+
+# Server
+PORT=8080
+NODE_ENV=development
+
+# Grownup Authentication
+GROWNUPS_PASSCODE=1234
+GROWNUPS_TOKEN_SECRET=
+
+# CORS
+ALLOWED_ORIGINS=http://localhost:3000
+
+# E2E Testing (do not set in production)
+# ENABLE_E2E_TEST_ROUTES=true
+# E2E_TEST_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,13 @@ Thumbs.db
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# Secrets
+*.pem
+*.key
+*.p12

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Richard Hewitt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,49 @@
-# Reading Quest
+Reading Quest
+=============
 
-A reading adventure app for kids.
+A reading adventure app for children aged 7–9. Kids explore story worlds, earn gems and stars, care for a virtual pet, and unlock new adventures — all while building reading confidence.
+
+## Features
+
+- Story worlds with chapters and comprehension
+- Virtual pet companion that grows with reading progress
+- Gems, stars, and XP reward system
+- Grown-ups dashboard with reading stats and vocabulary tracking
+- Passcode-protected parent controls
+- Data export for parent peace of mind
+
+## Architecture
+
+Monorepo (pnpm workspace):
+
+- **artifacts/api-server/** — Express 5 + PostgreSQL/Drizzle ORM
+- **artifacts/reading-quest/** — React 19 + Vite + TailwindCSS
+- **lib/api-spec/** — OpenAPI specification
+- **lib/api-zod/** — Generated Zod validators (via Orval)
+- **lib/api-client-react/** — Generated React Query hooks
+- **lib/db/** — Drizzle schema + migrations
+
+## Getting Started
+
+Prerequisites: Node.js 22+, pnpm 9+, PostgreSQL
+
+```sh
+cp .env.example .env   # then fill in values
+pnpm install
+pnpm run verify
+```
+
+## Scripts
+
+- `pnpm build` — Type-check and build all packages
+- `pnpm test` — Run unit tests
+- `pnpm test:e2e` — Run Playwright E2E tests
+- `pnpm verify` — Full verification (typecheck + build + test + e2e)
+
+## Deployment
+
+Configured for Replit Autoscale. See `replit.nix` and `.replit` for deployment settings.
+
+## License
+
+MIT

--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -55,4 +55,18 @@ if (process.env["NODE_ENV"] === "production") {
   });
 }
 
+// Global error-handling middleware (must be last).
+// Express 5 natively catches rejected promises from async route handlers.
+app.use(
+  (
+    err: Error,
+    req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    logger.error({ err, path: req.path, method: req.method }, "Unhandled error");
+    res.status(500).json({ error: "Internal server error" });
+  },
+);
+
 export default app;

--- a/scripts/post-merge.sh
+++ b/scripts/post-merge.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 pnpm install --frozen-lockfile
-pnpm --filter db push
+pnpm --filter @workspace/db push


### PR DESCRIPTION
## Summary

Six medium-priority fixes in a single branch:

### Fixes
| # | Issue | Change |
|---|-------|--------|
| 1 | **#6** — Error middleware | Added global error-handling middleware as the last `app.use()` in `app.ts`. Logs the error with pino and returns `500 { error: "Internal server error" }`. Express 5 natively catches async rejections, so no `asyncHandler` wrapper is needed. |
| 2 | **#7** — post-merge.sh filter | Changed `--filter db` → `--filter @workspace/db` to match the actual workspace package name. |
| 3 | **#8** — .env.example | Created `.env.example` documenting all required env vars (DATABASE_URL, PORT, NODE_ENV, GROWNUPS_PASSCODE, GROWNUPS_TOKEN_SECRET, ALLOWED_ORIGINS, E2E flags). |
| 4 | **#9** — LICENSE | Created MIT LICENSE file (Copyright © 2025 Richard Hewitt). |
| 5 | **#10** — README | Rewrote README with features, architecture, getting started, scripts, deployment, and license sections (British English). |
| 6 | **#11** — .gitignore | Added `.env`, `.env.*`, `!.env.example`, `*.pem`, `*.key`, `*.p12` to `.gitignore`. |

Closes #6, Closes #7, Closes #8, Closes #9, Closes #10, Closes #11